### PR TITLE
Identify extension-less files' types using hashbang lines

### DIFF
--- a/changelog.d/20231206_222443_kurtmckee_identify_extensionless_files.rst
+++ b/changelog.d/20231206_222443_kurtmckee_identify_extensionless_files.rst
@@ -1,0 +1,7 @@
+Added
+-----
+
+*   Use hashbang lines to determine the interpreter identity
+    for extension-less scripts.
+*   Support encoding comments near the tops of files for Python and Ruby.
+*   Support Perl file extensions.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,1 +1,6 @@
+..
+    This file is a part of Chipshot <https://github.com/kurtmckee/chipshot>
+    Copyright 2022-2023 Kurt McKee <contactme@kurtmckee.org>
+    SPDX-License-Identifier: MIT
+
 ..  include:: ../CHANGELOG.rst

--- a/src/chipshot/cli.py
+++ b/src/chipshot/cli.py
@@ -81,7 +81,7 @@ def run(
             log.debug(f"{path}: Empty file (no-op)")
             continue
 
-        info.header = render.render_header(path, configuration)
+        info.header = render.render_header(info, configuration)
 
         # If the headers match, do nothing.
         if info.header == info.original_header:
@@ -135,8 +135,9 @@ def _get_files(
             if not sub_path.is_file():
                 continue
 
-            # Ensure that there's a configuration to apply to this file.
-            if not _get_suffixes(sub_path) & configuration["extensions"].keys():
+            # Ensure that files with extensions have a configuration.
+            suffixes = _get_suffixes(sub_path)
+            if suffixes and not suffixes & configuration["extensions"].keys():
                 continue
 
             # Ensure that the path is not excluded.

--- a/src/chipshot/exceptions.py
+++ b/src/chipshot/exceptions.py
@@ -27,6 +27,10 @@ class FileDoesNotMatchBOMEncoding(FileDecodeError):
     """A file could not be decoded using the encoding specified by its BOM."""
 
 
+class FileDoesNotMatchEmbeddedEncoding(FileDecodeError):
+    """A file could not be decoded using the encoding embedded in the file."""
+
+
 class FileDoesNotMatchConfiguredEncoding(FileDecodeError):
     """A file could not be decoded using the encoding specified in the config."""
 

--- a/src/chipshot/reader/__init__.py
+++ b/src/chipshot/reader/__init__.py
@@ -9,7 +9,7 @@ import pathlib
 import typing as t
 
 from ..shared import FileInfo
-from . import encoding, header, newlines, prologue
+from . import encoding, header, identity, newlines, prologue
 
 log = logging.getLogger(__name__)
 
@@ -26,6 +26,7 @@ def read(path: pathlib.Path, config: dict[str, t.Any]) -> FileInfo:
 
     encoding.handle(info, config)
     newlines.handle(info)
+    identity.handle(info, config)
     prologue.handle(info, config)
     header.handle(info, config)
 

--- a/src/chipshot/reader/encoding.py
+++ b/src/chipshot/reader/encoding.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import codecs
 import logging
+import re
 import typing
 
 from .. import exceptions
@@ -15,13 +16,25 @@ from ..shared import FileInfo
 log = logging.getLogger(__name__)
 
 
+encoding_comment_pattern = re.compile(
+    r"\A(?:^#.*$\n)?#.*(?:en)?coding[\t ]*[:=][\t ]*(?P<encoding>[A-Za-z0-9_.-]+)",
+    flags=re.MULTILINE,
+)
+
+
 def handle(info: FileInfo, config: dict[str, typing.Any]) -> None:
     """Detect and handle the file encoding.
 
-    The encoding may be determined by a byte order mark at the beginning of the file.
+    The encoding may be embedded in the file in the following ways:
+
+    *   A byte order mark may appear in the first ~4 bytes of the file
+    *   An encoding comment that is ASCII-compatible may appear at the top of the file
+
+    If no embedded encoding is found (or honored),
+    Chipshot will use a configured encoding.
     """
 
-    # If the raw content has a byte order mark, ignore the default encoding.
+    # If the raw content has a byte order mark, use it.
     # Note that the order of these conditions is sensitive.
     if info.raw_contents.startswith(codecs.BOM_UTF32_BE):
         info.bom = codecs.BOM_UTF32_BE
@@ -38,15 +51,35 @@ def handle(info: FileInfo, config: dict[str, typing.Any]) -> None:
     elif info.raw_contents.startswith(codecs.BOM_UTF8):
         info.bom = codecs.BOM_UTF8
         info.encoding = "utf-8"
-    else:
-        (info.encoding,) = get_config_value(config, info.path, "encoding")
 
     if info.bom:
+        log.debug(f"{info.path}: Found BOM for encoding '{info.encoding}'")
         info.raw_contents = info.raw_contents[len(info.bom) :]
+        try:
+            info.contents = info.raw_contents.decode(info.encoding)
+        except UnicodeDecodeError:
+            raise exceptions.FileDoesNotMatchBOMEncoding
+        return
 
+    # If the file contains a "coding" or "encoding" comment, use it.
+    chunk = info.raw_contents[:500].decode("utf-8", errors="ignore")
+    match = encoding_comment_pattern.search(chunk)
+    if match is not None:
+        info.encoding = match.group("encoding")
+        log.debug(f"{info.path}: Found comment encoding '{info.encoding}'")
+        try:
+            info.contents = info.raw_contents.decode(info.encoding)
+        except LookupError:
+            log.debug(f"{info.path}: '{info.encoding}' is not a valid encoding")
+        except UnicodeDecodeError:
+            raise exceptions.FileDoesNotMatchEmbeddedEncoding
+        else:
+            return
+
+    # Fallback to a configured encoding.
+    (info.encoding,) = get_config_value(config, info, "encoding")
+    log.debug(f"{info.path}: Found configured encoding '{info.encoding}'")
     try:
         info.contents = info.raw_contents.decode(info.encoding)
     except UnicodeDecodeError:
-        if info.bom:
-            raise exceptions.FileDoesNotMatchBOMEncoding
         raise exceptions.FileDoesNotMatchConfiguredEncoding

--- a/src/chipshot/reader/header.py
+++ b/src/chipshot/reader/header.py
@@ -18,7 +18,7 @@ def handle(info: FileInfo, config: dict[str, t.Any]) -> None:
     """Detect and extract an existing header."""
 
     try:
-        (style_key,) = get_config_value(config, info.path, "style")
+        (style_key,) = get_config_value(config, info, "style")
     except KeyError:
         # If no style is defined for the file, do nothing.
         return

--- a/src/chipshot/reader/identity.py
+++ b/src/chipshot/reader/identity.py
@@ -1,0 +1,51 @@
+# This file is a part of Chipshot <https://github.com/kurtmckee/chipshot>
+# Copyright 2022-2023 Kurt McKee <contactme@kurtmckee.org>
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import typing
+
+from ..shared import FileInfo
+
+log = logging.getLogger(__name__)
+
+
+def handle(info: FileInfo, config: dict[str, typing.Any]) -> None:
+    """Determine the file type by examining the prologue."""
+
+    # If the file has an extension, do nothing.
+    if info.path.name.rfind(".") > 0:
+        log.debug(f"{info.path}: Skipping identity check because file has an extension")
+        return
+
+    # If the prologue doesn't start with a hashbang, do nothing.
+    if not info.contents.startswith("#!"):
+        log.debug(f"{info.path}: Skipping identity check because file has no hashbang")
+        return
+
+    for piece in info.contents[2:200].split()[:2]:
+        path = pathlib.PurePath(piece)
+
+        # Look for the full name.
+        name = path.name.lower()
+        if name in config["interpreters"]:
+            log.debug(f"{info.path}: Found interpreter '{name}'")
+            info.identity = config["interpreters"][name]
+            return
+
+        # Look for a version-less name.
+        name_without_version = name.rstrip("0123456789.")
+        if name_without_version in config["interpreters"]:
+            log.debug(f"{info.path}: Found versioned interpreter '{name}'")
+            info.identity = config["interpreters"][name_without_version]
+            return
+
+        # Try removing the extension (like "python.exe").
+        stem = path.stem
+        if stem in config["interpreters"]:
+            log.debug(f"{info.path}: Found base interpreter '{name}'")
+            info.identity = config["interpreters"][stem]
+            return

--- a/src/chipshot/reader/identity.py
+++ b/src/chipshot/reader/identity.py
@@ -27,7 +27,9 @@ def handle(info: FileInfo, config: dict[str, typing.Any]) -> None:
         return
 
     for piece in info.contents[2:200].split()[:2]:
-        path = pathlib.PurePath(piece)
+        # PureWindowsPath is compatible with both *nix and Windows paths,
+        # and ensures the name can be extracted, regardless of platform.
+        path = pathlib.PureWindowsPath(piece)
 
         # Look for the full name.
         name = path.name.lower()
@@ -43,7 +45,7 @@ def handle(info: FileInfo, config: dict[str, typing.Any]) -> None:
             info.identity = config["interpreters"][name_without_version]
             return
 
-        # Try removing the extension (like "python.exe").
+        # Try removing the extension (such as "python.exe" on Windows).
         stem = path.stem
         if stem in config["interpreters"]:
             log.debug(f"{info.path}: Found base interpreter '{name}'")

--- a/src/chipshot/reader/prologue.py
+++ b/src/chipshot/reader/prologue.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 def handle(info: FileInfo, config: dict[str, t.Any]) -> None:
     try:
-        (prologue_key,) = get_config_value(config, info.path, "prologue")
+        (prologue_key,) = get_config_value(config, info, "prologue")
     except KeyError:
         return
 
@@ -27,7 +27,7 @@ def handle(info: FileInfo, config: dict[str, t.Any]) -> None:
 
     pattern = re.compile(prologue_pattern, flags=re.M)
     match = pattern.search(info.contents)
-    if match is None:
+    if match is None or match.group() == "":
         return
 
     match_start, match_end = match.span(0)

--- a/src/chipshot/render.py
+++ b/src/chipshot/render.py
@@ -12,16 +12,17 @@ import jinja2
 
 from . import exceptions
 from .config import get_config_value
+from .shared import FileInfo
 
 
-def render_header(file: pathlib.Path, config: dict[str, t.Any]) -> str:
+def render_header(info: FileInfo, config: dict[str, t.Any]) -> str:
     """Render a (possibly file-specific) template into a header."""
 
     # Look for a template or template path.
     jinja_loader: jinja2.DictLoader | jinja2.FileSystemLoader
     try:
         template, template_path_str = get_config_value(
-            config, file, "template", "template_path"
+            config, info, "template", "template_path"
         )
     except KeyError:
         raise exceptions.NoTemplateDefined
@@ -47,7 +48,7 @@ def render_header(file: pathlib.Path, config: dict[str, t.Any]) -> str:
     )
 
     # Use the most specific style possible.
-    (style_key,) = get_config_value(config, file, "style")
+    (style_key,) = get_config_value(config, info, "style")
     style = config["styles"][style_key]
 
     lines: list[str] = []

--- a/src/chipshot/resources/default-config.toml
+++ b/src/chipshot/resources/default-config.toml
@@ -7,6 +7,20 @@ encoding = "utf-8"
 [prologues.hashbang]
 pattern = "^#!.+$"
 
+[prologues.hashbang-with-encoding]
+# Some programming languages support hashbangs and optional encoding comments.
+# These must be kept unseparated at the top of the file.
+#
+# https://peps.python.org/pep-0263/
+# https://docs.ruby-lang.org/en/master/syntax/comments_rdoc.html#label-Magic+Comments
+#
+# The following pattern matches:
+#   '#!hashbang'
+#   '# encoding'
+#   '#!hashbang' '\n' '# encoding'
+# It also matches empty strings, which is undesirable.
+pattern = "\\A(^#!.+$)?(?:(?(1)\\n|)^#.*(?:en)?coding[\\t ]*[:=].*$)?"
+
 [prologues.html_doctype]
 pattern = "(?i)^<\\!doctype(.|\\n)+>$"
 
@@ -15,7 +29,6 @@ pattern = "^(<\\?xml(.|\\n)+\\?>)?\\s*(?i)(^<\\!doctype(.|\\n)+>)?$"
 
 [prologues.xml_declaration]
 pattern = "^<\\?xml(.|\\n)+\\?>$"
-
 
 
 # Styles
@@ -142,21 +155,25 @@ style = "xml"
 [extensions.mermaid]
 style = "percent-percent"
 
+[extensions.pl]
+prologue = "hashbang"
+style = "hash"
+
 [extensions.ps1]
 style = "hash"
 prologue = "hashbang"
 
 [extensions.py]
+prologue = "hashbang-with-encoding"
 style = "hash"
-prologue = "hashbang"
 
 [extensions.r]
 style = "hash"
 prologue = "hashbang"
 
 [extensions.rb]
+prologue = "hashbang-with-encoding"
 style = "hash"
-prologue = "hashbang"
 
 [extensions.rs]
 style = "slash-slash"
@@ -196,3 +213,45 @@ prologue = "xhtml_declaration_and_doctype"
 [extensions.xml]
 style = "xml"
 prologue = "xml_declaration"
+
+
+# Interpreters
+# ------------
+
+[interpreters]
+bash = "shell"
+node = "javascript"
+nodejs = "javascript"
+perl = "perl"
+pwsh = "powershell"
+python = "python"
+ruby = "ruby"
+sh = "shell"
+
+
+# Types
+# -----
+
+[types.javascript]
+prologue = "hashbang"
+style = "slash-slash"
+
+[types.perl]
+prologue = "hashbang"
+style = "hash"
+
+[types.powershell]
+prologue = "hashbang"
+style = "hash"
+
+[types.python]
+prologue = "hashbang-with-encoding"
+style = "hash"
+
+[types.ruby]
+prologue = "hashbang-with-encoding"
+style = "hash"
+
+[types.shell]
+prologue = "hashbang"
+style = "hash"

--- a/src/chipshot/shared.py
+++ b/src/chipshot/shared.py
@@ -21,6 +21,7 @@ newline_type = t.Literal["", "\n", "\r", "\r\n"]
 class FileInfo:
     path: pathlib.Path
     raw_contents: bytes
+    identity: str = ""
     encoding: str = ""
     newlines: newline_type = ""
     bom: bom_type = b""

--- a/tests/test_reader_identity.py
+++ b/tests/test_reader_identity.py
@@ -1,0 +1,29 @@
+import pathlib
+
+import pytest
+
+import chipshot.reader.identity
+
+
+@pytest.mark.parametrize(
+    "prologue, expected",
+    (
+        # No-op
+        pytest.param("", "", id="empty prologue"),
+        pytest.param("bogus", "", id="not a hashbang"),
+        # Actual code
+        pytest.param("#!/usr/bin/python", "python", id="base executable name"),
+        pytest.param("#!/usr/bin/python3.11", "python", id="trailing version"),
+        pytest.param("#!/usr/bin/env python", "python", id="env"),
+        pytest.param(r"#!C:\Program Files\Python39\python.exe", "python", id="windows"),
+        # Loop exhaustion
+        pytest.param("#!env unknown -c", "", id="loop exhaustion"),
+    ),
+)
+def test_identity(bogus_file, default_config, prologue, expected):
+    bogus_file.path = pathlib.Path("script")
+    bogus_file.contents = prologue
+
+    chipshot.reader.identity.handle(bogus_file, default_config)
+
+    assert bogus_file.identity == expected

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -3,7 +3,8 @@ import textwrap
 
 import pytest
 
-import chipshot.render as csr
+import chipshot.render
+import chipshot.shared
 
 test_templates_root = (pathlib.Path(__file__).parent / "files/templates").resolve()
 rendered_files = [
@@ -16,7 +17,8 @@ rendered_files = [
 def test_render_header(default_config, rendered_file: pathlib.Path):
     default_config.update({"template_path": str(rendered_file.parent / "template.txt")})
     expected = rendered_file.read_text()
-    rendered = csr.render_header(rendered_file, default_config)
+    file = chipshot.shared.FileInfo(rendered_file, raw_contents=b"")
+    rendered = chipshot.render.render_header(file, default_config)
     fail_message = textwrap.dedent(
         """
         Expected:


### PR DESCRIPTION
Added
-----

*   Use hashbang lines to determine the interpreter identity    for extension-less scripts.
*   Support encoding comments near the tops of files for Python and Ruby.
*   Support Perl file extensions.
