### PR TITLE
Release 0.6.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         exclude: 'README.rst'
 
   - repo: 'https://github.com/python-jsonschema/check-jsonschema'
-    rev: '0.27.2'
+    rev: '0.27.3'
     hooks:
       - id: 'check-readthedocs'
       - id: 'check-dependabot'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,24 @@ Please see the fragment files in the `changelog.d directory`_.
 
 ..  scriv-insert-here
 
+.. _changelog-0.6.0:
+
+0.6.0 - 2023-12-07
+==================
+
+Added
+-----
+
+*   Use hashbang lines to determine the interpreter identity
+    for extension-less scripts.
+*   Support encoding comments near the tops of files for Python and Ruby.
+*   Support Perl file extensions.
+
+Changed
+-------
+
+*   Allow exclusions to match directories, too.
+
 .. _changelog-0.5.0:
 
 0.5.0 - 2023-12-04

--- a/changelog.d/20231206_222443_kurtmckee_identify_extensionless_files.rst
+++ b/changelog.d/20231206_222443_kurtmckee_identify_extensionless_files.rst
@@ -1,7 +1,0 @@
-Added
------
-
-*   Use hashbang lines to determine the interpreter identity
-    for extension-less scripts.
-*   Support encoding comments near the tops of files for Python and Ruby.
-*   Support Perl file extensions.

--- a/changelog.d/20231207_073026_kurtmckee_improve_exclusion_matching.rst
+++ b/changelog.d/20231207_073026_kurtmckee_improve_exclusion_matching.rst
@@ -1,4 +1,0 @@
-Changed
--------
-
-*   Allow exclusions to match directories, too.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "chipshot"
-version = "0.5.0"
+version = "0.6.0"
 description = "Set up game-winning headers!"
 readme = "README.rst"
 authors = ["Kurt McKee <contactme@kurtmckee.org>"]


### PR DESCRIPTION
- Always recreate the `update` environment
- Identify extension-less files' types using hashbang lines
- Fix a Windows/Linux compatibility issue
- Allow exclusions to match directories, too
- Update headers in the `tests/` directory
- Update project metadata
