### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       - id: "black"
 
   - repo: "https://github.com/pycqa/isort"
-    rev: "5.13.2"
+    rev: "6.0.0"
     hooks:
       - id: "isort"
 
@@ -49,24 +49,24 @@ repos:
     hooks:
       - id: "flake8"
         additional_dependencies:
-          - "flake8-bugbear==24.8.19"
+          - "flake8-bugbear==24.12.12"
 
-  - repo: "https://github.com/editorconfig-checker/editorconfig-checker.python"
-    rev: "3.0.3"
+  - repo: "https://github.com/editorconfig-checker/editorconfig-checker"
+    rev: "v3.2.0"
     hooks:
       - id: "editorconfig-checker"
         # The README contains YAML that isn't indented using 4 spaces.
         exclude: "README.rst"
 
   - repo: "https://github.com/python-jsonschema/check-jsonschema"
-    rev: "0.30.0"
+    rev: "0.31.0"
     hooks:
       - id: "check-readthedocs"
       - id: "check-dependabot"
       - id: "check-github-workflows"
 
   - repo: "https://github.com/rhysd/actionlint"
-    rev: "v1.7.6"
+    rev: "v1.7.7"
     hooks:
       - id: "actionlint"
 


### PR DESCRIPTION

This resolves pre-commit deprecation warnings about isort.
Also, switch to plain old editorconfig-checker.